### PR TITLE
Download latest version by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ fridaDownloader is a command-line tool that streamlines downloading the Frida Ga
 ## Features
 
 - **Download Options**: Easily download either the Frida Gadget or Server for Android.
-- **Latest Version**: Use the `--last-version` option to download the most recent version of Frida.
-- **Specific Version**: Specify a particular version of Frida to download using the `--version VERSION` option.
+- **Specific Version**: Specify a particular version of Frida to download using the `--version VERSION` option or it will download the latest version by default.
 - **Target Selection**: Choose the target for download with the `--target` option, allowing you to select either `gadget` or `server`.
 - **Architecture Support**: Select the appropriate Android architecture with the `--architecture` option. Supported architectures include:
   - `arm`
@@ -64,14 +63,13 @@ $: fridaDownloader -h
 *                           by hackermater  *
 *********************************************
 
-usage: fridaDownloader.py [-h] [--last-version] [--version VERSION] --target {gadget,server} [--architecture ARCHITECTURE]
+usage: fridaDownloader.py [-h] [--version VERSION] --target {gadget,server} [--architecture ARCHITECTURE]
                           [--output OUTPUT]
 
 Download Frida Gadget or Server for Android
 
 options:
   -h, --help            show this help message and exit
-  --last-version        Download the latest version of Frida
   --version VERSION     Download a specific version of Frida
   --target {gadget,server}
                         Specify the target to download: gadget or server
@@ -85,7 +83,7 @@ options:
 - Download the last version of Frida Server for x86 architecture:
 
 ```bash
-python3 fridaDownloader.py --target server --architecture x86 --last-version
+python3 fridaDownloader.py --target server --architecture x86
 ```
 
 - Download a specific version of Frida Gadget for arm64 architecture with specific output:

--- a/fridaDownloader.py
+++ b/fridaDownloader.py
@@ -83,7 +83,6 @@ def main():
 
     parser = argparse.ArgumentParser(description="Download Frida Gadget or Server for Android")
     
-    parser.add_argument('--last-version', action='store_true', help="Download the latest version of Frida")
     parser.add_argument('--version', type=str, help="Download a specific version of Frida")
     parser.add_argument('--target', type=str, choices=['gadget', 'server'], required=True, help="Specify the target to download: gadget or server")
     parser.add_argument('--architecture', type=str, default='arm', help="Android architecture (default: arm). Options: arm, arm64, x86, x86_64")
@@ -91,15 +90,13 @@ def main():
 
     args = parser.parse_args()
 
-    if args.last_version:
+    if args.version:
+        download_file(args.target, args.architecture, args.version, args.output)
+    else:
         print(f"{BRIGHT_YELLOW}[*] Fetching the latest version of Frida...{RESET}")
         latest_version = get_latest_version()
         if latest_version:
             download_file(args.target, args.architecture, latest_version, args.output)
-    elif args.version:
-        download_file(args.target, args.architecture, args.version, args.output)
-    else:
-        print(f"\n{BRIGHT_RED}[-] You must specify either --last-version or --version to download Frida.{RESET}")
 
 if __name__ == "__main__":
     main()

--- a/fridaDownloader/main.py
+++ b/fridaDownloader/main.py
@@ -83,7 +83,6 @@ def main():
 
     parser = argparse.ArgumentParser(description="Download Frida Gadget or Server for Android")
     
-    parser.add_argument('--last-version', action='store_true', help="Download the latest version of Frida")
     parser.add_argument('--version', type=str, help="Download a specific version of Frida")
     parser.add_argument('--target', type=str, choices=['gadget', 'server'], required=True, help="Specify the target to download: gadget or server")
     parser.add_argument('--architecture', type=str, default='arm', help="Android architecture (default: arm). Options: arm, arm64, x86, x86_64")
@@ -91,15 +90,13 @@ def main():
 
     args = parser.parse_args()
 
-    if args.last_version:
+    if args.version:
+        download_file(args.target, args.architecture, args.version, args.output)
+    else:
         print(f"{BRIGHT_YELLOW}[*] Fetching the latest version of Frida...{RESET}")
         latest_version = get_latest_version()
         if latest_version:
             download_file(args.target, args.architecture, latest_version, args.output)
-    elif args.version:
-        download_file(args.target, args.architecture, args.version, args.output)
-    else:
-        print(f"\n{BRIGHT_RED}[-] You must specify either --last-version or --version to download Frida.{RESET}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Hi there,

Thank you for creating such an awesome project! 🙌

I wanted to contribute by simplifying the download mechanism. Currently, users need to supply the `--last-version` flag to download the latest version. With this change, the tool will automatically download the latest version by default, making it more intuitive for users who may not be familiar with the flag.

I hope this helps streamline the experience!

Thanks!

```
% python fridaDownloader.py --target server

*********************************************
*  Welcome to the Frida Downloader          *
*                           by hackermater  *
*********************************************

[*] Fetching the latest version of Frida...
[*] Downloading Frida Server for Android Architecture arm from https://github.com/frida/frida/releases/download/16.6.6/frida-server-16.6.6-android-arm.xz
[+] Download completed successfully: /Users/xxx/Downloads/frida-server-16.6.6-android-arm.xz
[+] Decompression completed: /Users/xxx/Downloads/frida-server-16.6.6-android-arm
```